### PR TITLE
Add cluster and reader DNS names

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 ## Usage
 
 
-**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-documentdb-cluster/releases).
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-documentdb-cluster/releases).
+
+
 
 For a complete example, see [examples/complete](examples/complete)
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 ## Usage
 
 
-**IMPORTANT:** Do not pin to `master` because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-documentdb-cluster/releases).
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-documentdb-cluster/releases).
 
 For a complete example, see [examples/complete](examples/complete)
 
@@ -53,9 +53,9 @@ module "documentdb_cluster" {
   namespace               = "eg"
   stage                   = "testing"
   name                    = "docdb"
-  cluster_size            = "2"
-  admin_user              = "admin1"
-  admin_password          = "Test123456789"
+  cluster_size            = "3"
+  master_username         = "admin1"
+  master_password         = "Test123456789"
   instance_class          = "db.r4.large"
   vpc_id                  = "vpc-xxxxxxxx"
   subnet_ids              = ["subnet-xxxxxxxx", "subnet-yyyyyyyy"]
@@ -87,9 +87,10 @@ Available targets:
 | allowed_security_groups | List of existing Security Groups to be allowed to connect to the DocumentDB cluster | list | `<list>` | no |
 | apply_immediately | Specifies whether any cluster modifications are applied immediately, or during the next maintenance window | string | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
+| cluster_dns_name | Name of the cluster CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `master.var.name` | string | `` | no |
 | cluster_family | The family of the DocumentDB cluster parameter group. For more details, see https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-parameter-group-create.html | string | `docdb3.6` | no |
 | cluster_parameters | List of DB parameters to apply | list | `<list>` | no |
-| cluster_size | Number of DB instances to create in the cluster | string | `2` | no |
+| cluster_size | Number of DB instances to create in the cluster | string | `3` | no |
 | db_port | DocumentDB port | string | `27017` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
@@ -103,15 +104,16 @@ Available targets:
 | name | Name of the application | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | preferred_backup_window | Daily time range during which the backups happen | string | `07:00-09:00` | no |
+| reader_dns_name | Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `replicas.var.name` | string | `` | no |
 | retention_period | Number of days to retain backups for | string | `5` | no |
 | skip_final_snapshot | Determines whether a final DB snapshot is created before the DB cluster is deleted | string | `true` | no |
 | snapshot_identifier | Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot | string | `` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | storage_encrypted | Specifies whether the DB cluster is encrypted | string | `true` | no |
-| subnet_ids | List of VPC subnet IDs | list | - | yes |
+| subnet_ids | List of VPC subnet IDs to place DocumentDB instances | list | - | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | vpc_id | VPC ID to create the cluster in (e.g. `vpc-a22222ee`) | string | - | yes |
-| zone_id | Route53 parent zone ID. If provided (not empty), the module will create sub-domain DNS records for the DB master and replicas | string | `` | no |
+| zone_id | Route53 parent zone ID. If provided (not empty), the module will create sub-domain DNS records for the DocumentDB master and replicas | string | `` | no |
 
 ## Outputs
 

--- a/README.yaml
+++ b/README.yaml
@@ -60,7 +60,7 @@ description: |-
 # How to use this project
 usage: |-
 
-  **IMPORTANT:** Do not pin to `master` because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-documentdb-cluster/releases).
+  **IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-documentdb-cluster/releases).
 
   For a complete example, see [examples/complete](examples/complete)
 
@@ -70,9 +70,9 @@ usage: |-
     namespace               = "eg"
     stage                   = "testing"
     name                    = "docdb"
-    cluster_size            = "2"
-    admin_user              = "admin1"
-    admin_password          = "Test123456789"
+    cluster_size            = "3"
+    master_username         = "admin1"
+    master_password         = "Test123456789"
     instance_class          = "db.r4.large"
     vpc_id                  = "vpc-xxxxxxxx"
     subnet_ids              = ["subnet-xxxxxxxx", "subnet-yyyyyyyy"]

--- a/README.yaml
+++ b/README.yaml
@@ -60,8 +60,6 @@ description: |-
 # How to use this project
 usage: |-
 
-  **IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-documentdb-cluster/releases).
-
   For a complete example, see [examples/complete](examples/complete)
 
   ```hcl

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,9 +6,10 @@
 | allowed_security_groups | List of existing Security Groups to be allowed to connect to the DocumentDB cluster | list | `<list>` | no |
 | apply_immediately | Specifies whether any cluster modifications are applied immediately, or during the next maintenance window | string | `true` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
+| cluster_dns_name | Name of the cluster CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `master.var.name` | string | `` | no |
 | cluster_family | The family of the DocumentDB cluster parameter group. For more details, see https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-parameter-group-create.html | string | `docdb3.6` | no |
 | cluster_parameters | List of DB parameters to apply | list | `<list>` | no |
-| cluster_size | Number of DB instances to create in the cluster | string | `2` | no |
+| cluster_size | Number of DB instances to create in the cluster | string | `3` | no |
 | db_port | DocumentDB port | string | `27017` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage` and `attributes` | string | `-` | no |
 | enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
@@ -22,15 +23,16 @@
 | name | Name of the application | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | preferred_backup_window | Daily time range during which the backups happen | string | `07:00-09:00` | no |
+| reader_dns_name | Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `replicas.var.name` | string | `` | no |
 | retention_period | Number of days to retain backups for | string | `5` | no |
 | skip_final_snapshot | Determines whether a final DB snapshot is created before the DB cluster is deleted | string | `true` | no |
 | snapshot_identifier | Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot | string | `` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | storage_encrypted | Specifies whether the DB cluster is encrypted | string | `true` | no |
-| subnet_ids | List of VPC subnet IDs | list | - | yes |
+| subnet_ids | List of VPC subnet IDs to place DocumentDB instances | list | - | yes |
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | vpc_id | VPC ID to create the cluster in (e.g. `vpc-a22222ee`) | string | - | yes |
-| zone_id | Route53 parent zone ID. If provided (not empty), the module will create sub-domain DNS records for the DB master and replicas | string | `` | no |
+| zone_id | Route53 parent zone ID. If provided (not empty), the module will create sub-domain DNS records for the DocumentDB master and replicas | string | `` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "tags" {
 variable "zone_id" {
   type        = "string"
   default     = ""
-  description = "Route53 parent zone ID. If provided (not empty), the module will create sub-domain DNS records for the DB master and replicas"
+  description = "Route53 parent zone ID. If provided (not empty), the module will create sub-domain DNS records for the DocumentDB master and replicas"
 }
 
 variable "allowed_security_groups" {
@@ -61,7 +61,7 @@ variable "vpc_id" {
 
 variable "subnet_ids" {
   type        = "list"
-  description = "List of VPC subnet IDs"
+  description = "List of VPC subnet IDs to place DocumentDB instances"
 }
 
 variable "instance_class" {
@@ -72,7 +72,7 @@ variable "instance_class" {
 
 variable "cluster_size" {
   type        = "string"
-  default     = "2"
+  default     = "3"
   description = "Number of DB instances to create in the cluster"
 }
 
@@ -164,4 +164,16 @@ variable "enabled_cloudwatch_logs_exports" {
   type        = "list"
   description = "List of log types to export to cloudwatch. The following log types are supported: audit, error, general, slowquery."
   default     = []
+}
+
+variable "cluster_dns_name" {
+  type        = "string"
+  description = "Name of the cluster CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `master.var.name`"
+  default     = ""
+}
+
+variable "reader_dns_name" {
+  type        = "string"
+  description = "Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `replicas.var.name`"
+  default     = ""
 }


### PR DESCRIPTION
## what
* Add cluster and reader DNS names

## why
* The default DNS names can conflict with other database clusters when deployed together (e.g. RDS Aurora for Codefresh on-prem)
