### PR TITLE
add new attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -145,7 +146,7 @@ Available targets:
 | name | Name of the application | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
 | preferred\_backup\_window | Daily time range during which the backups happen | `string` | `"07:00-09:00"` | no |
-| preferred\_maintenance\_window | The window to perform maintenance in | `string` | `"Mon:22:00-Mon:23:00"` | no |
+| preferred\_maintenance\_window | The window to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`. | `string` | `"Mon:22:00-Mon:23:00"` | no |
 | reader\_dns\_name | Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `replicas.var.name` | `string` | `""` | no |
 | retention\_period | Number of days to retain backups for | `number` | `5` | no |
 | skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB cluster is deleted | `bool` | `true` | no |
@@ -172,6 +173,7 @@ Available targets:
 | security\_group\_id | ID of the DocumentDB cluster Security Group |
 | security\_group\_name | Name of the DocumentDB cluster Security Group |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Available targets:
 | allowed\_security\_groups | List of existing Security Groups to be allowed to connect to the DocumentDB cluster | `list(string)` | `[]` | no |
 | apply\_immediately | Specifies whether any cluster modifications are applied immediately, or during the next maintenance window | `bool` | `true` | no |
 | attributes | Additional attributes (\_e.g.\_ "1") | `list(string)` | `[]` | no |
+| auto\_minor\_version\_upgrade | Specifies whether any minor engine upgrades will be applied automatically to the DB instance during the maintenance window or not | `bool` | `true` | no |
 | cluster\_dns\_name | Name of the cluster CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `master.var.name` | `string` | `""` | no |
 | cluster\_family | The family of the DocumentDB cluster parameter group. For more details, see https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-parameter-group-create.html | `string` | `"docdb3.6"` | no |
 | cluster\_parameters | List of DB parameters to apply | <pre>list(object({<br>    apply_method = string<br>    name         = string<br>    value        = string<br>  }))</pre> | `[]` | no |
@@ -144,6 +145,7 @@ Available targets:
 | name | Name of the application | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
 | preferred\_backup\_window | Daily time range during which the backups happen | `string` | `"07:00-09:00"` | no |
+| preferred\_maintenance\_window | The window to perform maintenance in | `string` | `"Mon:22:00-Mon:23:00"` | no |
 | reader\_dns\_name | Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `replicas.var.name` | `string` | `""` | no |
 | retention\_period | Number of days to retain backups for | `number` | `5` | no |
 | skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB cluster is deleted | `bool` | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -38,7 +39,7 @@
 | name | Name of the application | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
 | preferred\_backup\_window | Daily time range during which the backups happen | `string` | `"07:00-09:00"` | no |
-| preferred\_maintenance\_window | The window to perform maintenance in | `string` | `"Mon:22:00-Mon:23:00"` | no |
+| preferred\_maintenance\_window | The window to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`. | `string` | `"Mon:22:00-Mon:23:00"` | no |
 | reader\_dns\_name | Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `replicas.var.name` | `string` | `""` | no |
 | retention\_period | Number of days to retain backups for | `number` | `5` | no |
 | skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB cluster is deleted | `bool` | `true` | no |
@@ -65,3 +66,4 @@
 | security\_group\_id | ID of the DocumentDB cluster Security Group |
 | security\_group\_name | Name of the DocumentDB cluster Security Group |
 
+<!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -20,6 +20,7 @@
 | allowed\_security\_groups | List of existing Security Groups to be allowed to connect to the DocumentDB cluster | `list(string)` | `[]` | no |
 | apply\_immediately | Specifies whether any cluster modifications are applied immediately, or during the next maintenance window | `bool` | `true` | no |
 | attributes | Additional attributes (\_e.g.\_ "1") | `list(string)` | `[]` | no |
+| auto\_minor\_version\_upgrade | Specifies whether any minor engine upgrades will be applied automatically to the DB instance during the maintenance window or not | `bool` | `true` | no |
 | cluster\_dns\_name | Name of the cluster CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `master.var.name` | `string` | `""` | no |
 | cluster\_family | The family of the DocumentDB cluster parameter group. For more details, see https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-parameter-group-create.html | `string` | `"docdb3.6"` | no |
 | cluster\_parameters | List of DB parameters to apply | <pre>list(object({<br>    apply_method = string<br>    name         = string<br>    value        = string<br>  }))</pre> | `[]` | no |
@@ -37,6 +38,7 @@
 | name | Name of the application | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
 | preferred\_backup\_window | Daily time range during which the backups happen | `string` | `"07:00-09:00"` | no |
+| preferred\_maintenance\_window | The window to perform maintenance in | `string` | `"Mon:22:00-Mon:23:00"` | no |
 | reader\_dns\_name | Name of the reader endpoint CNAME record to create in the parent DNS zone specified by `zone_id`. If left empty, the name will be auto-asigned using the format `replicas.var.name` | `string` | `""` | no |
 | retention\_period | Number of days to retain backups for | `number` | `5` | no |
 | skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB cluster is deleted | `bool` | `true` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -59,11 +59,13 @@ module "documentdb_cluster" {
   subnet_ids                      = module.subnets.private_subnet_ids
   zone_id                         = var.zone_id
   apply_immediately               = var.apply_immediately
+  auto_minor_version_upgrade      = var.auto_minor_version_upgrade
   allowed_security_groups         = var.allowed_security_groups
   allowed_cidr_blocks             = var.allowed_cidr_blocks
   snapshot_identifier             = var.snapshot_identifier
   retention_period                = var.retention_period
   preferred_backup_window         = var.preferred_backup_window
+  preferred_maintenance_window    = var.preferred_maintenance_window
   cluster_parameters              = var.cluster_parameters
   cluster_family                  = var.cluster_family
   engine                          = var.engine

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -120,6 +120,12 @@ variable "preferred_backup_window" {
   description = "Daily time range during which the backups happen"
 }
 
+variable "preferred_maintenance_window" {
+  type        = string
+  default     = "Mon:22:00-Mon:23:00"
+  description = "The window to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`."
+}
+
 variable "cluster_parameters" {
   type = list(object({
     apply_method = string
@@ -169,6 +175,12 @@ variable "skip_final_snapshot" {
 variable "apply_immediately" {
   type        = bool
   description = "Specifies whether any cluster modifications are applied immediately, or during the next maintenance window"
+  default     = true
+}
+
+variable "auto_minor_version_upgrade" {
+  type        = bool
+  description = "Specifies whether any minor engine upgrades will be applied automatically to the DB instance during the maintenance window or not"
   default     = true
 }
 

--- a/main.tf
+++ b/main.tf
@@ -75,14 +75,14 @@ resource "aws_docdb_cluster" "default" {
 }
 
 resource "aws_docdb_cluster_instance" "default" {
-  count                        = var.enabled ? var.cluster_size : 0
-  identifier                   = "${module.label.id}-${count.index + 1}"
-  cluster_identifier           = join("", aws_docdb_cluster.default.*.id)
-  apply_immediately            = var.apply_immediately
-  instance_class               = var.instance_class
-  tags                         = module.label.tags
-  engine                       = var.engine
-  auto_minor_version_upgrade   = var.auto_minor_version_upgrade
+  count                      = var.enabled ? var.cluster_size : 0
+  identifier                 = "${module.label.id}-${count.index + 1}"
+  cluster_identifier         = join("", aws_docdb_cluster.default.*.id)
+  apply_immediately          = var.apply_immediately
+  instance_class             = var.instance_class
+  tags                       = module.label.tags
+  engine                     = var.engine
+  auto_minor_version_upgrade = var.auto_minor_version_upgrade
 }
 
 resource "aws_docdb_subnet_group" "default" {

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,7 @@ resource "aws_docdb_cluster" "default" {
   apply_immediately               = var.apply_immediately
   storage_encrypted               = var.storage_encrypted
   kms_key_id                      = var.kms_key_id
+  protocol                        = var.db_port
   snapshot_identifier             = var.snapshot_identifier
   vpc_security_group_ids          = [join("", aws_security_group.default.*.id)]
   db_subnet_group_name            = join("", aws_docdb_subnet_group.default.*.name)
@@ -73,13 +74,15 @@ resource "aws_docdb_cluster" "default" {
 }
 
 resource "aws_docdb_cluster_instance" "default" {
-  count              = var.enabled ? var.cluster_size : 0
-  identifier         = "${module.label.id}-${count.index + 1}"
-  cluster_identifier = join("", aws_docdb_cluster.default.*.id)
-  apply_immediately  = var.apply_immediately
-  instance_class     = var.instance_class
-  tags               = module.label.tags
-  engine             = var.engine
+  count                        = var.enabled ? var.cluster_size : 0
+  identifier                   = "${module.label.id}-${count.index + 1}"
+  cluster_identifier           = join("", aws_docdb_cluster.default.*.id)
+  apply_immediately            = var.apply_immediately
+  instance_class               = var.instance_class
+  tags                         = module.label.tags
+  engine                       = var.engine
+  auto_minor_version_upgrade   = var.auto_minor_version_upgrade
+  preferred_maintenance_window = var.preferred_maintenance_window
 }
 
 resource "aws_docdb_subnet_group" "default" {

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,7 @@ resource "aws_docdb_cluster" "default" {
   master_password                 = var.master_password
   backup_retention_period         = var.retention_period
   preferred_backup_window         = var.preferred_backup_window
+  preferred_maintenance_window    = var.preferred_maintenance_window
   final_snapshot_identifier       = lower(module.label.id)
   skip_final_snapshot             = var.skip_final_snapshot
   apply_immediately               = var.apply_immediately
@@ -82,7 +83,6 @@ resource "aws_docdb_cluster_instance" "default" {
   tags                         = module.label.tags
   engine                       = var.engine
   auto_minor_version_upgrade   = var.auto_minor_version_upgrade
-  preferred_maintenance_window = var.preferred_maintenance_window
 }
 
 resource "aws_docdb_subnet_group" "default" {

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_docdb_cluster" "default" {
   apply_immediately               = var.apply_immediately
   storage_encrypted               = var.storage_encrypted
   kms_key_id                      = var.kms_key_id
-  protocol                        = var.db_port
+  port                            = var.db_port
   snapshot_identifier             = var.snapshot_identifier
   vpc_security_group_ids          = [join("", aws_security_group.default.*.id)]
   db_subnet_group_name            = join("", aws_docdb_subnet_group.default.*.name)

--- a/variables.tf
+++ b/variables.tf
@@ -116,6 +116,12 @@ variable "preferred_backup_window" {
   description = "Daily time range during which the backups happen"
 }
 
+variable "preferred_maintenance_window" {
+  type        = string
+  default     = "Mon:22:00-Mon:23:00"
+  description = "The window to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`."
+}
+
 variable "cluster_parameters" {
   type = list(object({
     apply_method = string
@@ -165,6 +171,12 @@ variable "skip_final_snapshot" {
 variable "apply_immediately" {
   type        = bool
   description = "Specifies whether any cluster modifications are applied immediately, or during the next maintenance window"
+  default     = true
+}
+
+variable "auto_minor_version_upgrade" {
+  type        = bool
+  description = "Specifies whether any minor engine upgrades will be applied automatically to the DB instance during the maintenance window or not"
   default     = true
 }
 


### PR DESCRIPTION
## what
* add option to change port for the cluster, the variable was defined but not used on the cluster resource so the SG was using it but not the cluster.
* add two attributes important to be sure no unexpected downtime without being planed: preferred_maintenance_window and auto_minor_version_upgrade

## why
* we want to have the cluster up to date on the last minor release
* we want to be able to change the default port

## references
* No issue or bug fix, just some additions