### PR TITLE
Also support aws provider 3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | local | ~> 1.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | local | ~> 1.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -15,7 +15,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.18.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -26,7 +26,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.16.1"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.31.0"
   availability_zones   = var.availability_zones
   namespace            = var.namespace
   stage                = var.stage

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 0.12.0"
 
   required_providers {
-    aws   = "~> 2.0"
+    aws   = ">= 2.0"
     local = "~> 1.3"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,7 @@ locals {
 }
 
 module "dns_master" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.5.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
   enabled = var.enabled && var.zone_id != "" ? true : false
   name    = local.cluster_dns_name
   zone_id = var.zone_id
@@ -128,7 +128,7 @@ module "dns_master" {
 }
 
 module "dns_replicas" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.5.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
   enabled = var.enabled && var.zone_id != "" ? true : false
   name    = local.replicas_dns_name
   zone_id = var.zone_id

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = "~> 2.0"
+    aws   = ">= 2.0"
     local = "~> 1.3"
   }
 }


### PR DESCRIPTION
## what
Set to use the latest version of dependencies and set to accept higher aws provider versions (3+)

## why
the latest aws provider now is 3.14.1, for this module to stay relevant it need to start support 3+.
There might be a point in creating 2 separate branches/tracks in the future since some 3+ things are not compatible with some 2+ things and vice versa.. I do not now if this module includes any issues like that, but the included "complete" test is ok with using the latest 3.14.1 provider at least.

## references
Direct links to the updated modules if curious what has changed in the versions (I didnt analyze just ran test and it worked
https://github.com/cloudposse/terraform-aws-vpc
https://github.com/cloudposse/terraform-aws-dynamic-subnets
https://github.com/cloudposse/terraform-aws-route53-cluster-hostname

Not for these particular changes Im doing a PR for now, but for reference what has changed between 2 and 3.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade

