### PR TITLE
Relax required Terraform version to >= 0.12.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0"
   enabled    = var.enabled
   namespace  = var.namespace
   name       = var.name
@@ -120,7 +120,7 @@ locals {
 }
 
 module "dns_master" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.8.0"
   enabled = var.enabled && var.zone_id != "" ? true : false
   name    = local.cluster_dns_name
   zone_id = var.zone_id
@@ -128,7 +128,7 @@ module "dns_master" {
 }
 
 module "dns_replicas" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.8.0"
   enabled = var.enabled && var.zone_id != "" ? true : false
   name    = local.replicas_dns_name
   zone_id = var.zone_id

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
     aws   = ">= 2.0"


### PR DESCRIPTION
This enables use of Terraform 0.14 which was recently released.

Requires this to be merged and released first: https://github.com/cloudposse/terraform-aws-route53-cluster-hostname/pull/29