### PR TITLE
Pass dns_name to terraform-aws-route53-cluster-hostname instead of name

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 
 
+## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
+
+Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
+
+| Benchmark | Description |
+|--------|---------------|
+| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-documentdb-cluster/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-documentdb-cluster&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
+| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-documentdb-cluster/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-documentdb-cluster&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
+| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-documentdb-cluster/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-documentdb-cluster&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
+| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-documentdb-cluster/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-documentdb-cluster&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
+| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-documentdb-cluster/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-documentdb-cluster&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
+| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-documentdb-cluster/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-documentdb-cluster&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
+| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-documentdb-cluster/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-documentdb-cluster&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
+| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-documentdb-cluster/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-documentdb-cluster&benchmark=SOC2)| Service Organization Control 2 Compliance |
+| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-documentdb-cluster/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-documentdb-cluster&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
+| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-documentdb-cluster/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-documentdb-cluster&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
+
+
+
 ## Usage
 
 
@@ -298,7 +317,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -109,23 +109,23 @@ locals {
 }
 
 module "dns_master" {
-  source  = "cloudposse/route53-cluster-hostname/aws"
-  version = "0.8.0"
-  enabled = module.this.enabled && var.zone_id != "" ? true : false
-  name    = local.cluster_dns_name
-  zone_id = var.zone_id
-  records = coalescelist(aws_docdb_cluster.default.*.endpoint, [""])
+  source   = "cloudposse/route53-cluster-hostname/aws"
+  version  = "0.8.0"
+  enabled  = module.this.enabled && var.zone_id != "" ? true : false
+  dns_name = local.cluster_dns_name
+  zone_id  = var.zone_id
+  records  = coalescelist(aws_docdb_cluster.default.*.endpoint, [""])
 
   context = module.this.context
 }
 
 module "dns_replicas" {
-  source  = "cloudposse/route53-cluster-hostname/aws"
-  version = "0.8.0"
-  enabled = module.this.enabled && var.zone_id != "" ? true : false
-  name    = local.replicas_dns_name
-  zone_id = var.zone_id
-  records = coalescelist(aws_docdb_cluster.default.*.reader_endpoint, [""])
+  source   = "cloudposse/route53-cluster-hostname/aws"
+  version  = "0.8.0"
+  enabled  = module.this.enabled && var.zone_id != "" ? true : false
+  dns_name = local.replicas_dns_name
+  zone_id  = var.zone_id
+  records  = coalescelist(aws_docdb_cluster.default.*.reader_endpoint, [""])
 
   context = module.this.context
 }


### PR DESCRIPTION
## what
* Fixes incorrect DNS records when setting custom records in R53 by passing `dns_name` rather than `name` to `terraform-aws-route53-cluster-hostname`

## why
* `terraform-aws-route53-cluster-hostname` changed how to pass the DNS name in between 0.5.0 and 0.7.0+
* In 0.5.0 the DNS record was created used `var.name` (https://github.com/cloudposse/terraform-aws-route53-cluster-hostname/blob/0.5.0/main.tf#L4) - which is what this module passes.
* Since 0.7.0 the DNS record created uses `var.dns_name` if set, defaulting to `module.this.id` if not (https://github.com/cloudposse/terraform-aws-route53-cluster-hostname/blob/0.7.0/main.tf#L3)
* This results in the custom DNS names passed in this module not generating the correct R53 records.
