### PR TITLE
fix: propagate `preferred_maintenance_window` to the docdb cluster instances resources

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,25 +1,25 @@
 output "master_username" {
-  value       = join("", aws_docdb_cluster.default.*.master_username)
+  value       = join("", aws_docdb_cluster.default[*].master_username)
   description = "Username for the master DB user"
 }
 
 output "cluster_name" {
-  value       = join("", aws_docdb_cluster.default.*.cluster_identifier)
+  value       = join("", aws_docdb_cluster.default[*].cluster_identifier)
   description = "Cluster Identifier"
 }
 
 output "arn" {
-  value       = join("", aws_docdb_cluster.default.*.arn)
+  value       = join("", aws_docdb_cluster.default[*].arn)
   description = "Amazon Resource Name (ARN) of the cluster"
 }
 
 output "endpoint" {
-  value       = join("", aws_docdb_cluster.default.*.endpoint)
+  value       = join("", aws_docdb_cluster.default[*].endpoint)
   description = "Endpoint of the DocumentDB cluster"
 }
 
 output "reader_endpoint" {
-  value       = join("", aws_docdb_cluster.default.*.reader_endpoint)
+  value       = join("", aws_docdb_cluster.default[*].reader_endpoint)
   description = "A read-only endpoint of the DocumentDB cluster, automatically load-balanced across replicas"
 }
 
@@ -35,15 +35,15 @@ output "replicas_host" {
 
 output "security_group_id" {
   description = "ID of the DocumentDB cluster Security Group"
-  value       = join("", aws_security_group.default.*.id)
+  value       = join("", aws_security_group.default[*].id)
 }
 
 output "security_group_arn" {
   description = "ARN of the DocumentDB cluster Security Group"
-  value       = join("", aws_security_group.default.*.arn)
+  value       = join("", aws_security_group.default[*].arn)
 }
 
 output "security_group_name" {
   description = "Name of the DocumentDB cluster Security Group"
-  value       = join("", aws_security_group.default.*.name)
+  value       = join("", aws_security_group.default[*].name)
 }


### PR DESCRIPTION
propagated `preferred_maintenance_window` to the docdb cluster instances resources

## what
* The maintenance window given as a variable is given to the Terraform Resource `aws_docdb_cluster_instance.default` such that the cluster and its instances have the same value given by the user
* Closes #55 

## why
* Without that the cluster instances were having "random" windows that don't match the expectations of "potential" down time
* Users want to be in control of when their databases can go under maintenance not just at any "random" time

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster_instance#preferred_maintenance_window
