### PR TITLE
Changed condition for password creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "aws_security_group_rule" "ingress_cidr_blocks" {
 }
 
 resource "random_password" "password" {
-  count   = module.this.enabled && var.master_password != "" ? 0 : 1
+  count   = module.this.enabled && var.master_password == "" ? 1 : 0
   length  = 16
   special = false
 }


### PR DESCRIPTION
When the module was disabled, a random password was still generated. Tweaked the condition to only be created if:
enabled = true && master_password =! ""

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
