### PR TITLE
feat: add storage_type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Available targets:
 | <a name="input_ssm_parameter_path_prefix"></a> [ssm\_parameter\_path\_prefix](#input\_ssm\_parameter\_path\_prefix) | The path prefix for the created SSM parameter e.g. '/docdb/master-password/dev'. `ssm_parameter_enabled` must be set to `true` for this to take affect. | `string` | `"/docdb/master-password/"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Specifies whether the DB cluster is encrypted | `bool` | `true` | no |
+| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | The storage type to associate with the DB cluster. Valid values: standard, iopt1 | `string` | `"standard"` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of VPC subnet IDs to place DocumentDB instances in | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 
 <!-- markdownlint-disable -->
-# terraform-aws-documentdb-cluster [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-documentdb-cluster.svg)](https://github.com/cloudposse/terraform-aws-documentdb-cluster/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+# terraform-aws-documentdb-cluster<a href="https://cpco.io/homepage"><img align="right" src="https://cloudposse.com/logo-300x69.svg" width="150" /></a> [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-documentdb-cluster.svg)](https://github.com/cloudposse/terraform-aws-documentdb-cluster/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 <!-- markdownlint-restore -->
 
-[![README Header][readme_header_img]][readme_header_link]
-
-[![Cloud Posse][logo]](https://cpco.io/homepage)
 
 <!--
 
@@ -30,24 +27,17 @@
 
 Terraform module to provision an [`Amazon DocumentDB`](https://aws.amazon.com/documentdb/) cluster.
 
+
 ---
+> [!NOTE]
+> This project is part of Cloud Posse's comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
+> <a href="https://cpco.io/terraform-modules"><img src="https://docs.cloudposse.com/images/terraform-open-source-modules.svg" align="right" /></a>
+>
+> It's 100% Open Source and licensed under the [APACHE2](LICENSE).
+>
+> We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out!
 
-This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
-<a href="https://cpco.io/terraform-modules"><img src="https://docs.cloudposse.com/images/terraform-open-source-modules.svg" align="right" /></a>
-
-
-It's 100% Open Source and licensed under the [APACHE2](LICENSE).
-
-
-
-
-
-
-
-We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out!
-
-
-
+[![README Header][readme_header_img]][readme_header_link]
 
 
 
@@ -57,7 +47,7 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 
 > **Important**
-> We do not pin modules to versions in our examples because of the
+> We do not pin modules to versions in Cloud Posse's examples because of the
 > difficulty of keeping the versions in the documentation in sync with the latest released versions.
 > We highly recommend that in your code you pin the version to the exact version you are
 > using so that your infrastructure remains stable, and update versions in a
@@ -265,7 +255,7 @@ Please use the [issue tracker](https://github.com/cloudposse/terraform-aws-docum
 
 ### 💻 Developing
 
-If you are interested in being a contributor and want to get involved in developing this project or [help out](https://cpco.io/help-out) with our other projects, we would love to hear from you! Shoot us an [email][email].
+If you are interested in being a contributor and want to get involved in developing this project or [help out](https://cpco.io/help-out) with Cloud Posse's other projects, we would love to hear from you! Shoot us an [email][email].
 
 In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
@@ -343,7 +333,7 @@ under the License.
 
 All other trademarks referenced herein are the property of their respective owners.
 ---
-Copyright © 2017-2023 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2024 [Cloud Posse, LLC](https://cpco.io/copyright)
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
 <!-- markdownlint-disable -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -93,6 +93,7 @@
 | <a name="input_ssm_parameter_path_prefix"></a> [ssm\_parameter\_path\_prefix](#input\_ssm\_parameter\_path\_prefix) | The path prefix for the created SSM parameter e.g. '/docdb/master-password/dev'. `ssm_parameter_enabled` must be set to `true` for this to take affect. | `string` | `"/docdb/master-password/"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Specifies whether the DB cluster is encrypted | `bool` | `true` | no |
+| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | The storage type to associate with the DB cluster. Valid values: standard, iopt1 | `string` | `"standard"` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of VPC subnet IDs to place DocumentDB instances in | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,7 @@ resource "aws_docdb_cluster" "default" {
   deletion_protection             = var.deletion_protection
   apply_immediately               = var.apply_immediately
   storage_encrypted               = var.storage_encrypted
+  storage_type                    = var.storage_type
   kms_key_id                      = var.kms_key_id
   port                            = var.db_port
   snapshot_identifier             = var.snapshot_identifier

--- a/variables.tf
+++ b/variables.tf
@@ -151,6 +151,12 @@ variable "storage_encrypted" {
   default     = true
 }
 
+variable "storage_type" {
+  type        = string
+  description = "The storage type to associate with the DB cluster. Valid values: standard, iopt1"
+  default     = "standard"
+}
+
 variable "kms_key_id" {
   type        = string
   description = "The ARN for the KMS encryption key. When specifying `kms_key_id`, `storage_encrypted` needs to be set to `true`"

--- a/variables.tf
+++ b/variables.tf
@@ -155,6 +155,11 @@ variable "storage_type" {
   type        = string
   description = "The storage type to associate with the DB cluster. Valid values: standard, iopt1"
   default     = "standard"
+
+  validation {
+    condition     = contains(["standard", "iopt1"], var.storage_type)
+    error_message = "Error: storage_type value must be one of two options - 'standard' or 'iopt1'."
+  }
 }
 
 variable "kms_key_id" {


### PR DESCRIPTION
## what

Amazon has [announced](https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-documentdb-i-o-optimized/) IO-optimized storage type for DocumentDB. Support for it has been added since HashiCorp AWS provider version [5.29.0](https://registry.terraform.io/providers/hashicorp/aws/5.29.0/docs/resources/docdb_cluster#storage_type)

## why

Keep standard as default but also add ability to create IO-optimized DocumentDB clusters.

## references

[https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-documentdb-i-o-optimized/](https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-documentdb-i-o-optimized/)
[https://registry.terraform.io/providers/hashicorp/aws/5.29.0/docs/resources/docdb_cluster#storage_type](https://registry.terraform.io/providers/hashicorp/aws/5.29.0/docs/resources/docdb_cluster#storage_type)
