### PR TITLE
fix: upgrade aws provider to 5.29.0 to support storage_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.29.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 1.0 |
 
@@ -110,7 +110,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.21.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.29.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 1.0 |
 
 ## Modules

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.21.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.29.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 1.0 |
 
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.21.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.29.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 1.0 |
 
 ## Modules

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -31,6 +31,8 @@ engine = "docdb"
 
 storage_encrypted = true
 
+storage_type = "standard"
+
 skip_final_snapshot = true
 
 apply_immediately = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -60,6 +60,7 @@ module "documentdb_cluster" {
   engine                          = var.engine
   engine_version                  = var.engine_version
   storage_encrypted               = var.storage_encrypted
+  storage_type                    = var.storage_type
   kms_key_id                      = var.kms_key_id
   skip_final_snapshot             = var.skip_final_snapshot
   enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -119,6 +119,12 @@ variable "storage_encrypted" {
   default     = true
 }
 
+variable "storage_type" {
+  type        = string
+  description = "The storage type to associate with the DB cluster. Valid values: standard, iopt1"
+  default     = "standard"
+}
+
 variable "kms_key_id" {
   type        = string
   description = "The ARN for the KMS encryption key. When specifying `kms_key_id`, `storage_encrypted` needs to be set to `true`"

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -123,6 +123,11 @@ variable "storage_type" {
   type        = string
   description = "The storage type to associate with the DB cluster. Valid values: standard, iopt1"
   default     = "standard"
+
+  validation {
+    condition     = contains(["standard", "iopt1"], var.storage_type)
+    error_message = "Error: storage_type value must be one of two options - 'standard' or 'iopt1'."
+  }
 }
 
 variable "kms_key_id" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.21.0"
+      version = ">= 5.29.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- Upgrade terraform-aws-provider to 5.29.0
- Add variable for storage_type in the test.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- storage_type was released in 5.29.0 but the current minimum version is 5.21.0. This change corrects the minimum required version to 5.29.0
 
## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
closes https://github.com/cloudposse/terraform-aws-documentdb-cluster/issues/86

- https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.29.0