### PR TITLE
feat: added output cluster_members for resource aws_docdb_cluster

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -30,7 +30,7 @@ output "reader_endpoint" {
 }
 
 output "cluster_members" {
-  value = flatten(aws_docdb_cluster.default[*].cluster_members)
+  value       = flatten(aws_docdb_cluster.default[*].cluster_members)
   description = "List of DocumentDB Instances that are a part of this cluster"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,8 +30,8 @@ output "reader_endpoint" {
 }
 
 output "cluster_members" {
-  value = aws_docdb_cluster.default[*].cluster_members
-  description = "List of lists of DocumentDB Instances that are a part of this cluster"
+  value = flatten(aws_docdb_cluster.default[*].cluster_members)
+  description = "List of DocumentDB Instances that are a part of this cluster"
 }
 
 output "master_host" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,6 +29,11 @@ output "reader_endpoint" {
   description = "A read-only endpoint of the DocumentDB cluster, automatically load-balanced across replicas"
 }
 
+output "cluster_members" {
+  value = aws_docdb_cluster.default[*].cluster_members
+  description = "List of lists of DocumentDB Instances that are a part of this cluster"
+}
+
 output "master_host" {
   value       = module.dns_master.hostname
   description = "DB master hostname"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
--> Added the Output "cluster_members" for the resource "aws_docdb_cluster".

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
--> Needed for monitoring reasons of the DocumentDB Cluster on a Node-level. Needed when creating a CloudWatch alarm on Node-level because the Dimesion  of the alarm needs the cluster memebers.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
--> https://docs.aws.amazon.com/documentdb/latest/developerguide/cloud_watch.html#:~:text=and%20ReadIOPS.-,Amazon%20DocumentDB%20dimensions,-The%20metrics%20for
