### PR TITLE
fix: address invalid count bug

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -95,7 +95,7 @@ variable "master_username" {
 
 variable "master_password" {
   type        = string
-  default     = ""
+  default     = null
   description = "(Required unless a snapshot_identifier is provided) Password for the master DB user. Note that this may show up in logs, and it will be stored in the state file. Please refer to the DocumentDB Naming Constraints"
 }
 


### PR DESCRIPTION
## what and why

- If a `data.aws_ssm_parameter.password.value` is passed to this module, it is tagged as a sensitive in the AWS provider, and that tag travels with the value all the way into the module. Because we don’t mark variable `master_password` as `sensitive = true`, the value is off-limits to functions like `length()` or to meta-arguments like `count`. Terraform refuses to evaluate them → “invalid count argument”.
