### PR TITLE
Add support for managed master credentials

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   enabled         = module.this.enabled
-  create_password = local.enabled && var.master_password == null && !var.manage_master_user_password
+  create_password = local.enabled && var.master_password == null && (var.manage_master_user_password == null || !var.manage_master_user_password)
   master_password = local.create_password ? one(random_password.password[*].result) : var.master_password
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   enabled         = module.this.enabled
-  create_password = local.enabled && var.master_password == null
+  create_password = local.enabled && var.master_password == null && !var.manage_master_user_password
 
   master_password = local.create_password ? one(random_password.password[*].result) : var.master_password
 }

--- a/main.tf
+++ b/main.tf
@@ -167,7 +167,7 @@ module "ssm_write_db_password" {
   source  = "cloudposse/ssm-parameter-store/aws"
   version = "0.13.0"
 
-  enabled = local.enabled && var.ssm_parameter_enabled == true && var.manage_master_user_password != null ? true : false
+  enabled = local.enabled && var.ssm_parameter_enabled == true && var.manage_master_user_password != true ? true : false
   parameter_write = [
     {
       name        = format("%s%s", var.ssm_parameter_path_prefix, module.this.id)

--- a/main.tf
+++ b/main.tf
@@ -80,6 +80,7 @@ resource "aws_docdb_cluster" "default" {
   kms_key_id                      = var.kms_key_id
   port                            = var.db_port
   snapshot_identifier             = var.snapshot_identifier
+  manage_master_user_password     = var.manage_master_user_password
   vpc_security_group_ids          = concat([join("", aws_security_group.default[*].id)], var.external_security_group_id_list)
   db_subnet_group_name            = join("", aws_docdb_subnet_group.default[*].name)
   db_cluster_parameter_group_name = join("", aws_docdb_cluster_parameter_group.default[*].name)
@@ -166,7 +167,7 @@ module "ssm_write_db_password" {
   source  = "cloudposse/ssm-parameter-store/aws"
   version = "0.13.0"
 
-  enabled = local.enabled && var.ssm_parameter_enabled == true ? true : false
+  enabled = local.enabled && var.ssm_parameter_enabled == true && var.manage_master_user_password != null ? true : false
   parameter_write = [
     {
       name        = format("%s%s", var.ssm_parameter_path_prefix, module.this.id)

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "master_username" {
 }
 
 output "master_password" {
-  value       = var.manage_master_user_password == null || !var.manage_master_user_password ? join("", aws_docdb_cluster.default[*].master_password) : null
+  value       = !var.manage_master_user_password ? join("", aws_docdb_cluster.default[*].master_password) : null
   description = "Password for the master DB user. If `manage_master_user_password` is set to true, this will be set to null."
   sensitive   = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,8 +4,8 @@ output "master_username" {
 }
 
 output "master_password" {
-  value       = join("", aws_docdb_cluster.default[*].master_password)
-  description = "Password for the master DB user"
+  value       = !var.manage_master_user_password ? join("", aws_docdb_cluster.default[*].master_password) : null
+  description = "Password for the master DB user. If `manage_master_user_password` is set to true, this will be set to null."
   sensitive   = true
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "master_username" {
 }
 
 output "master_password" {
-  value       = !var.manage_master_user_password ? join("", aws_docdb_cluster.default[*].master_password) : null
+  value       = var.manage_master_user_password == null || !var.manage_master_user_password ? join("", aws_docdb_cluster.default[*].master_password) : null
   description = "Password for the master DB user. If `manage_master_user_password` is set to true, this will be set to null."
   sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -244,4 +244,8 @@ variable "manage_master_user_password" {
   type        = bool
   description = "Whether to manage the master user password using AWS Secrets Manager. Cannot be set if `master_password` is set."
   default     = null
+  validation {
+    condition     = var.manage_master_user_password == null || var.master_password == null
+    error_message = "Error: `manage_master_user_password` cannot be set if `master_password` is set."
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -239,3 +239,9 @@ variable "allow_major_version_upgrade" {
   description = "Specifies whether major version upgrades are allowed. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster#allow_major_version_upgrade"
   default     = false
 }
+
+variable "manage_master_user_password" {
+  type        = bool
+  description = "Whether to manage the the master user password using AWS Secrets Manager. If set to `true`, the `master_password` variable must be set to `null`."
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -244,8 +244,4 @@ variable "manage_master_user_password" {
   type        = bool
   description = "Whether to manage the master user password using AWS Secrets Manager. Cannot be set if `master_password` is set."
   default     = null
-  validation {
-    condition     = var.manage_master_user_password == null || var.master_password == null
-    error_message = "Error: `manage_master_user_password` cannot be set if `master_password` is set."
-  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -242,6 +242,6 @@ variable "allow_major_version_upgrade" {
 
 variable "manage_master_user_password" {
   type        = bool
-  description = "Whether to manage the the master user password using AWS Secrets Manager. If set to `true`, the `master_password` variable must be set to `null`."
+  description = "Whether to manage the the master user password using AWS Secrets Manager. Cannot be set if `master_password` is set."
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -242,6 +242,6 @@ variable "allow_major_version_upgrade" {
 
 variable "manage_master_user_password" {
   type        = bool
-  description = "Whether to manage the the master user password using AWS Secrets Manager. Cannot be set if `master_password` is set."
+  description = "Whether to manage the master user password using AWS Secrets Manager. Cannot be set if `master_password` is set."
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -242,6 +242,10 @@ variable "allow_major_version_upgrade" {
 
 variable "manage_master_user_password" {
   type        = bool
-  description = "Whether to manage the master user password using AWS Secrets Manager. Cannot be set if `master_password` is set."
-  default     = null
+  description = <<-EOT
+  Whether to manage the master user password using AWS Secrets Manager.
+  If set to true, `master_password` will be be ignored.
+  This parameter is given priority over `master_password`.
+  EOT
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -243,5 +243,5 @@ variable "allow_major_version_upgrade" {
 variable "manage_master_user_password" {
   type        = bool
   description = "Whether to manage the master user password using AWS Secrets Manager. Cannot be set if `master_password` is set."
-  default     = null
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -243,5 +243,5 @@ variable "allow_major_version_upgrade" {
 variable "manage_master_user_password" {
   type        = bool
   description = "Whether to manage the master user password using AWS Secrets Manager. Cannot be set if `master_password` is set."
-  default     = false
+  default     = null
 }


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- Added one additional variable that will allow users to manage their master credentials using AWS Secrets Manager.
## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- This is a native feature of the core DocumentDB resource that should be supported by this module.
## references
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster#manage_master_user_password-1
<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
