### PR TITLE
Fix the logic of the check on var.manage_master_user_password in outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "master_username" {
 }
 
 output "master_password" {
-  value       = var.manage_master_user_password != null ? join("", aws_docdb_cluster.default[*].master_password) : null
+  value       = var.manage_master_user_password == null ? join("", aws_docdb_cluster.default[*].master_password) : null
   description = "Password for the master DB user. If `manage_master_user_password` is set to true, this will be set to null."
   sensitive   = true
 }


### PR DESCRIPTION
If manage_master_user_password is null, then a master password has been set (provided or generated), otherwise there is no password to output so set it to null

## what
The new logic introduced to support managed master password (#124) was wrong for the master_password output. This PR fixes it.

## why
Was triggering the following error when var.manage_master_user_password was set to `true`.
```
│ Error: Invalid function argument
│ 
│   on .terraform/modules/documentdb/outputs.tf line 7, in output "master_password":
│    7:   value       = var.manage_master_user_password != null ? join("", aws_docdb_cluster.default[*].master_password) : null
│     ├────────────────
│     │ while calling join(separator, lists...)
│     │ aws_docdb_cluster.default is tuple with 1 element
│ 
│ Invalid value for "lists" parameter: element 0 is null; cannot concatenate null values.
```

## references
Fixes #126, #127, #128

