### PR TITLE
fix: adjust logic to address `manage_master_user_password` variable bugs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "aws_docdb_cluster" "default" {
   cluster_identifier = module.this.id
   master_username    = var.master_username
   # If `master_password` or `manage_master_user_password` is set, the other MUST be set to null, otherwise it will cause an error.
-  master_password                 = var.manage_master_user_password ? null : local.master_password
+  master_password                 = var.manage_master_user_password != null ? null : local.master_password
   manage_master_user_password     = var.manage_master_user_password
   backup_retention_period         = var.retention_period
   preferred_backup_window         = var.preferred_backup_window

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   enabled         = module.this.enabled
-  create_password = local.enabled && var.master_password == null && !var.manage_master_user_password
-  # If both `var.master_password` is null and `var.manage_master_user_password` is false, the module will create a random password
+  create_password = local.enabled && var.master_password == null && var.manage_master_user_password == null
+  # If both `var.master_password` is null and `var.manage_master_user_password` is null, the module will create a random password
   # else `local.master_password` is set to the value provided in `var.master_password`
   master_password = local.create_password ? one(random_password.password[*].result) : var.master_password
 }

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,8 @@
 locals {
   enabled         = module.this.enabled
-  create_password = local.enabled && var.master_password == null && var.manage_master_user_password == null
-  // If both `var.master_password` and `var.manage_master_user_password` are set to null, the module will create a random password
-  // else if `var.master_password` is set to null - master_password is set to null as `manage_master_user_password` is set to true
-  // else `local.master_password` is set to the value provided in `var.master_password`
+  create_password = local.enabled && var.master_password == null && !var.manage_master_user_password
+  # If both `var.master_password` is null and `var.manage_master_user_password` is false, the module will create a random password
+  # else `local.master_password` is set to the value provided in `var.master_password`
   master_password = local.create_password ? one(random_password.password[*].result) : var.master_password
 }
 
@@ -70,7 +69,7 @@ resource "aws_docdb_cluster" "default" {
   cluster_identifier = module.this.id
   master_username    = var.master_username
   # If `master_password` or `manage_master_user_password` is set, the other MUST be set to null, otherwise it will cause an error.
-  master_password                 = local.master_password
+  master_password                 = var.manage_master_user_password ? null : local.master_password
   manage_master_user_password     = var.manage_master_user_password
   backup_retention_period         = var.retention_period
   preferred_backup_window         = var.preferred_backup_window

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,8 +4,8 @@ output "master_username" {
 }
 
 output "master_password" {
-  value       = var.manage_master_user_password != null ? join("", aws_docdb_cluster.default[*].master_password) : null
-  description = "Password for the master DB user. If `manage_master_user_password` is set to true, this will be set to null."
+  value       = var.manage_master_user_password ? null : local.master_password
+  description = "Password for the master DB user. If `manage_master_user_password` is set to true, this will be set to null and the password is managed by AWS in Secrets Manager."
   sensitive   = true
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "master_username" {
 }
 
 output "master_password" {
-  value       = var.manage_master_user_password ? null : local.master_password
+  value       = var.manage_master_user_password == true ? null : local.master_password
   description = "Password for the master DB user. If `manage_master_user_password` is set to true, this will be set to null and the password is managed by AWS in Secrets Manager."
   sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -101,12 +101,8 @@ variable "master_password" {
 
 variable "manage_master_user_password" {
   type        = bool
+  default     = false
   description = "Whether to manage the master user password using AWS Secrets Manager."
-  default     = null
-  validation {
-    condition     = var.manage_master_user_password == null || var.manage_master_user_password == true
-    error_message = "Error: `manage_master_user_password` must be set to `true` or `null`"
-  }
 }
 
 variable "retention_period" {

--- a/variables.tf
+++ b/variables.tf
@@ -101,8 +101,12 @@ variable "master_password" {
 
 variable "manage_master_user_password" {
   type        = bool
-  default     = false
   description = "Whether to manage the master user password using AWS Secrets Manager."
+  default     = null
+  validation {
+    condition     = var.manage_master_user_password == null || var.manage_master_user_password == true
+    error_message = "Error: `manage_master_user_password` must be set to `true` or `null`"
+  }
 }
 
 variable "retention_period" {


### PR DESCRIPTION
## what and why

- This PR fixes critical bugs created when the `manage_master_user_password` variable was introduced. The first bug caused a Terraform error where the `master_password` output attempted to join a `null` value when AWS was managing the password, failing with "Invalid function argument: cannot concatenate null values." 
- These fixes ensure that when `manage_master_user_password = null` (default), random passwords are created and stored in SSM as expected, and when `manage_master_user_password = true`, AWS manages the password without attempting to expose it in Terraform outputs or store it in SSM, maintaining both backward compatibility and the intended security

### bug

```console
│ Error: Invalid function argument
│ 
│   on .terraform/modules/documentdb/outputs.tf line 7, in output "master_password":
│    7:   value       = var.manage_master_user_password != null ? join("", aws_docdb_cluster.default[*].master_password) : null
│     ├────────────────
│     │ while calling join(separator, lists...)
│     │ aws_docdb_cluster.default is tuple with 1 element
│ 
│ Invalid value for "lists" parameter: element 0 is null; cannot concatenate null values.
```

## references

- Closes #126 
- Closes #127 
- Closes #128 
