### PR TITLE
In place DocDB version upgrading

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ resource "aws_docdb_subnet_group" "default" {
 # https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-parameter-group-create.html
 resource "aws_docdb_cluster_parameter_group" "default" {
   count       = local.enabled ? 1 : 0
-  name        = module.this.id
+  name        = "${module.this.id}-v-${replace(var.cluster_family, ".", "-")}"
   description = "DB cluster parameter group"
   family      = var.cluster_family
 


### PR DESCRIPTION
## what
- Changes how docdb parameter groups are named

## why

- Recently, we wanted to upgrade DocDB version 4 to 5 using terraform and AWS in-place major version upgrade (MVU), but were unable to due to following error: (see references)

- The issue occurs because paramter groups need a unique name and are tied to a specific version(see image ref 1). If you want to make an MVU you need to 1: Create a new paramter group with a unique name and your specific cluster version, because you cannot upgrade or reuse old paramter groups 2: Apply new version + supply new parameter group.

- Currently, it's impossible to upgrade to a new docdb version using this module. This module always creates a parameter group with the same name as the cluster. If you want to upgrade, the cluster name has to stay the same. Therefor, terraform will try to create a parameter group for the new version but will fail to do so since a parameter group with that name already exists. You cannot have 2 parameter groups with the same name even if they are tied to different versions (see image ref 2). Therefor, a way to create unique names for each version is required.

How does MVU work with this proposed change?
1. Terraform will create a new parameter group at the beginning 
2. Terraform will upgrade the cluster and supply the new parameter group
3. After the cluster upgrade, it will delete the old parameter group

Why not change the name of the cluster?
- If you change just the name of the cluster, it will create a second cluster beside your old one and then proceed to destroy the old one (see image ref 3)

Is this a breaking change for already existing infrastructure?
No, but it will need a reboot to apply the changes.  (see image ref 4 & 5)

## image ref
```
Error: creating DocumentDB Cluster Parameter Group (docdb): operation error DocDB: CreateDBClusterParameterGroup, https response error StatusCode: 400, RequestID: 453f9c50-a040-46fa-b9b3-b4bab8fccbbb, DBParameterGroupAlreadyExists: Parameter group docdb already exists

   with module.ecs.module.documentdb_cluster.aws_docdb_cluster_parameter_group.default[0],
   on .terraform/modules/ecs.documentdb_cluster/main.tf line 109, in resource "aws_docdb_cluster_parameter_group" "default":
  109: resource "aws_docdb_cluster_parameter_group" "default" {
```

Image Ref 1:
<img width="595" height="89" alt="image" src="https://github.com/user-attachments/assets/112c863c-8bab-4a4e-8435-438ebcf9de6c" />

Image Ref 2:
<img width="986" height="404" alt="image" src="https://github.com/user-attachments/assets/5d7c395c-b9f8-484a-bf89-6a94b68114cf" />

Image Ref 3:
<img width="933" height="317" alt="image" src="https://github.com/user-attachments/assets/d11942da-c4e4-4029-b321-36d5e8ad034d" />

Image Ref 4:
<img width="1384" height="247" alt="image" src="https://github.com/user-attachments/assets/e2e47af2-8e6c-469e-acac-9ac266175124" />

Image Ref 5:
<img width="1379" height="252" alt="image" src="https://github.com/user-attachments/assets/f1c7883f-70a0-4703-8e47-b5e6ab46ac58" />

## references

https://github.com/cloudposse/terraform-aws-documentdb-cluster/issues/116