### PR TITLE
feat: add `copy_tags_to_snapshot` support for cluster instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,6 +116,7 @@ resource "aws_docdb_cluster_instance" "default" {
   cluster_identifier           = join("", aws_docdb_cluster.default[*].id)
   apply_immediately            = var.apply_immediately
   preferred_maintenance_window = var.preferred_maintenance_window
+  copy_tags_to_snapshot        = var.copy_tags_to_snapshot
   instance_class               = var.instance_class
   engine                       = var.engine
   auto_minor_version_upgrade   = var.auto_minor_version_upgrade

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,12 @@ variable "preferred_maintenance_window" {
   description = "The window to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`."
 }
 
+variable "copy_tags_to_snapshot" {
+  type        = bool
+  default     = false
+  description = "Copy all DB instance tags to snapshots."
+}
+
 variable "cluster_parameters" {
   type = list(object({
     apply_method = string


### PR DESCRIPTION
## what

* Added the `copy_tags_to_snapshot` variable in `variables.tf` to allow users to specify whether all DB instance tags should be copied to snapshots.
* Updated the `aws_docdb_cluster_instance` resource in `main.tf` to use the new `copy_tags_to_snapshot` variable, enabling this functionality in cluster instance creation.

## why

- This introduces a new configuration option for Amazon DocumentDB cluster instances to control whether tags are copied to snapshots. The main change is the addition of the `copy_tags_to_snapshot` variable and its integration into the resource definition, allowing users to manage tag copying behavior more flexibly.

## references

- [Terraform Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster_instance)
